### PR TITLE
Add support for arbitrary headers (like Date).

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,7 +42,8 @@ type Message struct {
 
 	Attachments []Attachment // optional
 
-	// TODO(JPOEHLS): Support extra mail headers? Things like On-Behalf-Of, In-Reply-To, List-Unsubscribe, etc.
+	// Extra mail headers.
+	Headers mail.Header
 }
 
 // An Attachment represents an email attachment.
@@ -125,6 +126,10 @@ func (m *Message) Bytes() ([]byte, error) {
 	// Optional Subject
 	if m.Subject != "" {
 		header.Add("Subject", qEncodeAndWrap(m.Subject, 9 /* len("Subject: ") */))
+	}
+
+	for k, v := range m.Headers {
+		header[k] = v
 	}
 
 	// Top level multipart writer for our `multipart/mixed` body.

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package gophermail
 
 import (
 	"testing"
+	"net/mail"
+	"time"
 )
 
 func Test_Bytes(t *testing.T) {
@@ -11,6 +13,8 @@ func Test_Bytes(t *testing.T) {
 	m.Subject = "My Subject (abcdefghijklmnop qrstuvwxyz0123456789 abcdefghijklmnopqrstuvwxyz0123456789_567890)"
 	m.Body = "My Plain Text Body"
 	m.HTMLBody = "<p>My <b>HTML</b> Body</p>"
+	m.Headers = mail.Header{}
+	m.Headers["Date"] = []string{time.Now().UTC().Format(time.RFC822)}
 
 	bytes, err := m.Bytes()
 	if err != nil {


### PR DESCRIPTION
I've writing a program where I'd like to be able to set arbitrary dates on the mail I send.  Gophermail does almost everything I need except for this.  It was a pretty small patch to add support for arbitrary headers, what do you think?
