### PR TITLE
Turned HTMLBody into a bytes.Buffer

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,9 @@
 package gophermail
 
 import (
-	"testing"
+	"bytes"
 	"net/mail"
+	"testing"
 	"time"
 )
 
@@ -12,7 +13,7 @@ func Test_Bytes(t *testing.T) {
 	m.To = []string{"to_1@domain.com", "to_2@domain.com"}
 	m.Subject = "My Subject (abcdefghijklmnop qrstuvwxyz0123456789 abcdefghijklmnopqrstuvwxyz0123456789_567890)"
 	m.Body = "My Plain Text Body"
-	m.HTMLBody = "<p>My <b>HTML</b> Body</p>"
+	m.HTMLBody = *bytes.NewBufferString("<p>My <b>HTML</b> Body</p>")
 	m.Headers = mail.Header{}
 	m.Headers["Date"] = []string{time.Now().UTC().Format(time.RFC822)}
 


### PR DESCRIPTION
Hi,

This switch allows you to use the message.HTMLBody as a Writer for html/template.

``` go
var mailBodyTpl = template.Must(template.ParseFiles("NewsTpl.html"))

msg := gophermail.Message{
    To:      []string{t.Email},
    From:    "webmaster@somewhere.de",
    Subject: "News! News! News!",
}

// construct the args...

mailBodyTpl.Execute(&msg.HTMLBody, tplArgs)
checkErr(err)

// send the mail
```
