### PR TITLE
Add support for Content-ID attachments, for using attachments in html email

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,6 +114,11 @@ type Attachment struct {
 	// to application/octet-stream if unknown.
 	ContentType string
 
+	// Optional.
+	// Used for embedding attachments inline in
+	// email messages (e.g. <img src="cid:<ContentID>"/>).
+	ContentID string
+
 	Data io.Reader
 }
 
@@ -266,6 +271,9 @@ func (m *Message) Bytes() ([]byte, error) {
 
 			header := textproto.MIMEHeader{}
 			header.Add("Content-Type", contentType)
+			if attachment.ContentID != "" {
+				header.Add("Content-ID", attachment.ContentID)
+			}
 			header.Add("Content-Disposition", fmt.Sprintf(`attachment;%s filename="%s"`, crlf, attachment.Name))
 			header.Add("Content-Transfer-Encoding", "base64")
 


### PR DESCRIPTION
I'm not sure if this is something you want to support, but we needed it, so I wrote it.

We were trying to embed images in our html messages through Amazon SES using gophermail, when we found out that Amazon SES doesn't support embedded images.  However, it does support using Content-ID in attachments, which allows for using the attachments within the email for things like <img> tags.

This patch adds a ContentID field to the Attachment struct, which is used in Message.Bytes as an attachment's "Content-ID" header, if the value is non-empty.

The Content-ID header requires the value to be enclosed in angle brackets, and it appears to work best when the value is something like `"<image1.jpg@domain.com>"`, but this patch doesn't enforce any of that structure.  I just needed rudimentary support for my testing.  If you'd like it to enforce some/all of that structure, I can of course add it in.
