### PR TITLE
fixes quoted subjects in plain-ascii subject lines

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/sloonz/go-qprintable"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -12,6 +11,8 @@ import (
 	"net/textproto"
 	"path/filepath"
 	"strings"
+
+	"github.com/sloonz/go-qprintable"
 )
 
 // Message Lint: http://tools.ietf.org/tools/msglint/
@@ -339,9 +340,9 @@ func writeHeader(w io.Writer, header textproto.MIMEHeader) error {
 // Inspired by https://gist.github.com/andelf/5004821
 func qEncode(input string) string {
 	// use mail's rfc2047 to encode any string
-	addr := mail.Address{input, ""}
+	addr := mail.Address{input + string(0), ""}
 	s := addr.String()
-	return s[:len(s)-3]
+	return s[:len(s)-8] + "?="
 }
 
 // qEncodeAndWrap encodes the input as potentially multiple 'encoded-words'


### PR DESCRIPTION
go 1.3 made a minor edit to how mail.Address determines whether a string
consists of unicode characters or not.[1] It now also considers whitespace to be
ascii characters. This has always been an issue with subject lines that only
consist of a single word and no spaces, but I had never encountered that case
until now. Essentially all subject lines with ascii/whitespace are now quoted
with plain-quotes, such as "hello there". When the subject lines are
unicode-encoded the quotes are dropped which is what I assume is the desired
behaviour for the vast majority of cases (and the reason this was never an
issue).

This fix simply writes a zero byte to the end of the address, forcing it to be
encoded as unicode by mail.Address.String(). It then strips back the trailing
bytes from the output and appends the proper suffix.

[1] https://code.google.com/p/go/source/diff?spec=svn04a5bbd18c65d2763d5a088d0c7b84c35d5ebcea&r=9623db1cea8778640e38026b6e1bc2e1c9f0db70&format=side&path=/src/pkg/net/mail/message.go&old_path=/src/pkg/net/mail/message.go&old=6752a7aad603fdad5782db3ab9b08577635c7cf8