### PR TITLE
Strip basic quoting from email subjects - resolves #14

### DIFF
--- a/main.go
+++ b/main.go
@@ -164,7 +164,13 @@ func (m *Message) Bytes() ([]byte, error) {
 
 	// Optional Subject
 	if m.Subject != "" {
-		header.Add("Subject", qEncodeAndWrap(m.Subject, 9 /* len("Subject: ") */))
+		quotedSubject := qEncodeAndWrap(m.Subject, 9 /* len("Subject: ") */)
+		if quotedSubject[0] == '"' {
+			// qEncode used simple quoting, which adds quote
+			// characters to email subjects.
+			quotedSubject = quotedSubject[1 : len(quotedSubject)-1]
+		}
+		header.Add("Subject", quotedSubject)
 	}
 
 	for k, v := range m.Headers {


### PR DESCRIPTION
This adds some simple logic to check for basic quoting of the email subject, and strip it out if it's being used.  RFC2047 quoting using `=?charset?encoding?encoded-text?=` won't be affected, but simple quoting using " characters will be stripped from email subjects.

It solved my issues related to #14, and AFAIK shouldn't change anything else.
