### PR TITLE
Fix panic on Go 1.5

### DIFF
--- a/main.go
+++ b/main.go
@@ -345,9 +345,9 @@ func writeHeader(w io.Writer, header textproto.MIMEHeader) error {
 // Inspired by https://gist.github.com/andelf/5004821
 func qEncode(input string) string {
 	// use mail's rfc2047 to encode any string
-	addr := mail.Address{Name: input, Address: ""}
+	addr := mail.Address{Name: input, Address: "a@b.c"}
 	s := addr.String()
-	return s[:len(s)-3]
+	return s[:len(s)-8]
 }
 
 // qEncodeAndWrap encodes the input as potentially multiple 'encoded-words'


### PR DESCRIPTION
net/mail's Address.String() panics if the address doesn't contain a "@"
in Go 1.5

See https://github.com/golang/go/commit/daaa45073e887cb6d8075c2caafdfe8425bca25a

Fixes #24