### PR TITLE
Fix Appended Quotes

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/sloonz/go-qprintable"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -12,6 +11,8 @@ import (
 	"net/textproto"
 	"path/filepath"
 	"strings"
+
+	"github.com/sloonz/go-qprintable"
 )
 
 // Message Lint: http://tools.ietf.org/tools/msglint/
@@ -120,9 +121,13 @@ type Attachment struct {
 // Bytes gets the encoded MIME message.
 func (m *Message) Bytes() ([]byte, error) {
 	var buffer = &bytes.Buffer{}
-
 	header := textproto.MIMEHeader{}
 
+	return m.bytes(buffer, header)
+}
+
+// bytes gets the encoded MIME message
+func (m *Message) bytes(buffer *bytes.Buffer, header textproto.MIMEHeader) ([]byte, error) {
 	var err error
 
 	// Require To, Cc, or Bcc
@@ -168,7 +173,7 @@ func (m *Message) Bytes() ([]byte, error) {
 		if quotedSubject[0] == '"' {
 			// qEncode used simple quoting, which adds quote
 			// characters to email subjects.
-			quotedSubject = quotedSubject[1 : len(quotedSubject)-1]
+			quotedSubject = quotedSubject[1 : len(quotedSubject)-2]
 		}
 		header.Add("Subject", quotedSubject)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,10 +1,22 @@
 package gophermail
 
 import (
+	"bytes"
 	"net/mail"
+	"net/textproto"
 	"testing"
 	"time"
 )
+
+func simpleMessage() *Message {
+	m := &Message{}
+	m.SetFrom("Doman Sender <sender@domain.com>")
+	m.AddTo("First person <to_1@domain.com>")
+	m.Subject = "My Subject"
+	m.Body = "My Plain Text Body"
+
+	return m
+}
 
 func Test_Bytes(t *testing.T) {
 	m := &Message{}
@@ -28,4 +40,42 @@ func Test_Bytes(t *testing.T) {
 	}
 
 	t.Logf("%s", bytes)
+}
+
+func TestSubjectHeaderWithSimpleQuoting(t *testing.T) {
+	m := simpleMessage()
+	m.Subject = "My Subject"
+	buf := new(bytes.Buffer)
+	header := textproto.MIMEHeader{}
+
+	_, err := m.bytes(buf, header)
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+	expected := "My Subject"
+	if sub := header.Get("Subject"); sub != expected {
+		t.Logf(`Expected Subject to be "%s" but got "%s"`, expected, sub)
+		t.Fail()
+	}
+}
+
+func TestSubjectHeaderWithExistingQuotes(t *testing.T) {
+	m := simpleMessage()
+	m.Subject = `"Hi World"`
+	buf := new(bytes.Buffer)
+	header := textproto.MIMEHeader{}
+
+	_, err := m.bytes(buf, header)
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+	expected := `\"Hi World\"`
+	if sub := header.Get("Subject"); sub != expected {
+		t.Logf(`Expected Subject to be "%s" but got "%s"`, expected, sub)
+		t.Fail()
+	}
 }


### PR DESCRIPTION
fixes #26 

Remove appended quote to the subject header.  Refactored `Message.Bytes()` to expose headers to testing while minimizing refactorings and without changing the interface.