### PR TITLE
add quote in subject test

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -44,7 +44,7 @@ func Test_Bytes(t *testing.T) {
 
 func TestSubjectHeaderWithSimpleQuoting(t *testing.T) {
 	m := simpleMessage()
-	m.Subject = "My Subject"
+	m.Subject = "My \"Sub\"ject"
 	buf := new(bytes.Buffer)
 	header := textproto.MIMEHeader{}
 
@@ -54,7 +54,7 @@ func TestSubjectHeaderWithSimpleQuoting(t *testing.T) {
 		t.Fail()
 	}
 
-	expected := "My Subject"
+	expected := "My \"Sub\"ject"
 	if sub := header.Get("Subject"); sub != expected {
 		t.Logf(`Expected Subject to be "%s" but got "%s"`, expected, sub)
 		t.Fail()


### PR DESCRIPTION
So if you have a quotation mark in your subject it's going to add a backslash before it. as this test is failing now:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jpoehls/gophermail/32)
<!-- Reviewable:end -->
