### PR TITLE
Fix mishandled From address

### DIFF
--- a/smtp.go
+++ b/smtp.go
@@ -53,7 +53,7 @@ func SendTLSMail(addr string, a smtp.Auth, msg *Message, cfg tls.Config) error {
 		to = append(to, address.Address)
 	}
 
-    from := msg.From.String()
+    from := msg.From.Address
 
 	c, err := smtp.Dial(addr)
 	if err != nil {


### PR DESCRIPTION
Some smtp servers will fail if you issue the MAIL command with an
address surrounded by brackets. Likewise, using .Address here matches
the smtp.SendMail call in the SendMail function above